### PR TITLE
Set category to designing

### DIFF
--- a/wakatime_blender/heartbeat_queue.py
+++ b/wakatime_blender/heartbeat_queue.py
@@ -118,6 +118,8 @@ class HeartbeatQueue(threading.Thread):
             f"{heartbeat.timestamp:f}",
             "--plugin",
             ua,
+            "--category",
+            "designing"
         ]
         props = WakatimeProjectProperties.instance()
         if props and props.always_overwrite_name:


### PR DESCRIPTION
#7 

To provide better categorizing of Blender projects in various charts and visualizations, added designing category to allow for visual separation from coding work.